### PR TITLE
Http monit check

### DIFF
--- a/jobs/proxy-agent/spec
+++ b/jobs/proxy-agent/spec
@@ -3,6 +3,7 @@ name: proxy-agent
 templates:
   settings.yml.erb: config/settings.yml
   proxy-agent_ctl.erb: bin/proxy-agent_ctl
+  drain-proxy.erb: bin/drain
 
 packages:
 - common

--- a/jobs/proxy-agent/templates/drain-proxy.erb
+++ b/jobs/proxy-agent/templates/drain-proxy.erb
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+RUN_DIR=/var/vcap/sys/run/proxy-agent
+PIDFILE=$RUN_DIR/proxy-agent.pid
+
+if [ -f $PIDFILE ]; then
+  pid=$(cat $PIDFILE)
+  kill $pid        # process is running; kill it softly
+  sleep 10         # wait a bit
+  kill -9 $pid     # kill it hard
+  rm -rf $PIDFILE # remove pid file
+fi
+
+echo 0 # ok to exit; do not wait for anything
+
+exit 0

--- a/jobs/squid/monit
+++ b/jobs/squid/monit
@@ -6,5 +6,5 @@ check process squid
 
 
 check program http-check with path "/var/vcap/jobs/squid/bin/http-check.sh"
-  if status != 0 for 6 cycles then exec "/var/vcap/bosh/bin/monit restart all"
+  if status != 0 for 12 cycles then exec "/var/vcap/jobs/squid/bin/http-check-reload.sh"
   group vcap

--- a/jobs/squid/spec
+++ b/jobs/squid/spec
@@ -5,6 +5,8 @@ templates:
   squid_reload.erb: bin/squid_reload
   squid.conf.erb: config/squid.conf
   http-check.sh.erb: bin/http-check.sh
+  http-check-reload.sh.erb: bin/http-check-reload.sh
+
 
 packages:
   - squid

--- a/jobs/squid/templates/http-check-reload.sh.erb
+++ b/jobs/squid/templates/http-check-reload.sh.erb
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# stop monit
+/var/vcap/bosh/bin/monit monit stop -g vcap
+
+# wait for processes to stop
+sleep 60
+
+# force kill squid and proxy-agent process if still running
+pkill squid
+ps -ef | grep puma | grep -v grep | awk '{print $2}' | xargs kill -9       
+
+# wait for processes to kill
+sleep 10 
+
+# start monit again
+/var/vcap/bosh/bin/monit start -g vcap

--- a/jobs/squid/templates/http-check-reload.sh.erb
+++ b/jobs/squid/templates/http-check-reload.sh.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # stop monit
-/var/vcap/bosh/bin/monit monit stop -g vcap
+/var/vcap/bosh/bin/monit stop -g vcap
 
 # wait for processes to stop
 sleep 60


### PR DESCRIPTION
changed monit to run script on fail rather than restart command and aded drain script for proxy agent.