### PR TITLE
Make proxy health check more robust and fix custom property

### DIFF
--- a/jobs/squid/spec
+++ b/jobs/squid/spec
@@ -22,7 +22,7 @@ properties:
     description: 'Password for HTTP proxy check'
   squid.http_check.test_endpoint:
     description: 'Endpoint for HTTP proxy check'
-  squid.conf:
+  squid.custom:
     default: |
       connect_timeout 60 seconds
       connect_retries 0

--- a/jobs/squid/templates/http-check.sh.erb
+++ b/jobs/squid/templates/http-check.sh.erb
@@ -7,7 +7,7 @@ PROXY_PASS="<%= p('squid.http_check.password') %>"
 PROXY_URL="http://$PROXY_USER:$PROXY_PASS@127.0.0.1:3128"
 TEST_ENDPOINT="<%= p('squid.http_check.test_endpoint') %>"
 
-RESPONSE=$(curl -x $PROXY_URL $TEST_ENDPOINT)
+RESPONSE=$(curl -sS --retry 3 -x $PROXY_URL $TEST_ENDPOINT)
 
 if [ "$RESPONSE" = "[All_OK]" ]
 then

--- a/jobs/squid/templates/squid.conf.erb
+++ b/jobs/squid/templates/squid.conf.erb
@@ -41,8 +41,8 @@ http_port 3128
 
 workers <%= p('squid.workers') %>
 
-# Additional Squid configuration
-<%= p('squid.config') %>
+# Additional custom ad-hoc squid configuration
+<%= p('squid.custom') %>
 
 cache_mem 1024 MB
 


### PR DESCRIPTION
Retry connection 3 times, with progressive back-off (1, 2, 4s).
Hide progress bar and report only errors (currently
errors are not fully seen as the progress bar consumes
most of log space and gets actual error message truncated).

Also fix custom squid config handling and property names.